### PR TITLE
Fix badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Website Status](https://img.shields.io/website/http/max-question-answering.max.us-south.containers.appdomain.cloud/swagger.json.svg?label=api+demo)](http://max-question-answering-web-app.max.us-south.containers.appdomain.cloud/)
+[![Website Status](https://img.shields.io/website/http/max-question-answering.max.us-south.containers.appdomain.cloud/swagger.json.svg?label=api+demo)](http://max-question-answering.max.us-south.containers.appdomain.cloud/) [![Website Status](https://img.shields.io/website/http/max-question-answering-web-app.max.us-south.containers.appdomain.cloud.svg)](http://max-question-answering-web-app.max.us-south.containers.appdomain.cloud/)
 
 # Create a machine learning powered web app to answer questions
 

--- a/app.py
+++ b/app.py
@@ -68,7 +68,7 @@ def get_subtitles(data, titles, title):
         return final
 
 
-@app.route("/", methods=["POST", "GET"])
+@app.route("/", methods=["POST", "GET", "HEAD"])
 def chat():
     if request.method == "POST":
         '''Process an ongoing conversation.'''

--- a/app.py
+++ b/app.py
@@ -87,7 +87,7 @@ def chat():
         response, new_state, matches = get_next_text(model_endpoint, input_text, narrowed_titles)
         return jsonify({"response": response, "state": new_state, "matches": matches})
 
-    elif request.method == "GET":
+    else:
         '''Start a conversation.'''
         return render_template("index.html", display_text=get_opening_message(), state=1)
 


### PR DESCRIPTION
Addresses #15 

Spoke with Alex about this and learned that shields.io makes a HEAD request to the server to check if it's up or not. We didn't have a route for HEAD so it was returning a 500 error. This PR updates the badges and adds the HEAD route.

Tested this by running it locally and running `curl -I http://0.0.0.0:8000/ ` to verify the server returns a 200 response code.